### PR TITLE
data type optimizations

### DIFF
--- a/26304_ANSI-C_source_code_v6_6_0/c-code/Makefile
+++ b/26304_ANSI-C_source_code_v6_6_0/c-code/Makefile
@@ -2,4 +2,5 @@ dummy:
 	@# i686-w64-mingw32-gcc -Wall -s -o decoder-new.exe common/*.c lib_amr/*.c decoder/*.c 3gplib/Release/er-libisomedia.dll -L3gplib/Release/ -l3gplib -lm
 	@# i686-w64-mingw32-gcc -O2 -s -o decoder-new.exe common/*.c lib_amr/*.c decoder/*.c 3gplib/Release/er-libisomedia.dll -L3gplib/Release/ -l3gplib -lm
 	gcc -Wno-incompatible-pointer-types -Wno-implicit-function-declaration -Wno-unused-result -Wno-multichar -O2 -s -o decoder-new common/*.c lib_amr/*.c decoder/*.c libbase/*.c -lm
+	gcc -Wno-incompatible-pointer-types -Wno-implicit-function-declaration -Wno-unused-result -Wno-multichar -O2 -s -o encoder-new common/*.c lib_amr/*.c encoder/*.c libbase/*.c -lm
 	@# i686-w64-mingw32-gcc -s -O2 -o encoder-new.exe common/*.c lib_amr/*.c encoder/*.c 3gplib/Release/er-libisomedia.dll -L3gplib/Release/ -l3gplib -lm

--- a/26304_ANSI-C_source_code_v6_6_0/c-code/lib_amr/typedef.h
+++ b/26304_ANSI-C_source_code_v6_6_0/c-code/lib_amr/typedef.h
@@ -5,13 +5,14 @@
  */
 #ifndef typedef_h
 #define typedef_h
+#include <stdint.h>
 
 /* change these typedef declarations to correspond with your platform */
-typedef char           Word8;
-typedef unsigned char  UWord8;
-typedef short          Word16;
-typedef unsigned short UWord16;
-typedef long           Word32;
+typedef int8_t         Word8;
+typedef uint8_t        UWord8;
+typedef int16_t        Word16;
+typedef uint16_t       UWord16;
+typedef int32_t        Word32;
 typedef double         Float64;
 typedef float          Float32;
 

--- a/26304_ANSI-C_source_code_v6_6_0/c-code/libbase/MP4Atoms.h
+++ b/26304_ANSI-C_source_code_v6_6_0/c-code/libbase/MP4Atoms.h
@@ -1240,7 +1240,7 @@ typedef struct MP4ItemPropertyContainerAtom {
 } MP4ItemPropertyContainerAtom, *MP4ItemPropertyContainerAtomPtr;
 
 typedef struct MP4ItemPropertyAssociationEntryPropertyIndex {
-	u8  essential;
+	u16  essential;
 	u16 property_index;
 } MP4ItemPropertyAssociationEntryPropertyIndex, *MP4ItemPropertyAssociationEntryPropertyIndexPtr;
 


### PR DESCRIPTION
You might also want to take a look at me changing the u8 to u16 in MP4Atoms.h.
There was a compiler overflow warning from ItemPropertyAssociationAtom.c:243:60 and indeed the u8 is too small to hold a 1<<15. I am unsure of what the original idea was here but it might very well be this code is never executed in this project anyways.
